### PR TITLE
Upgrade Django to 2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM grahamdumpleton/mod-wsgi-docker:python-3.5
 
 RUN apt-get update && \
-            apt-get install -y --no-install-recommends git \
-            python-pip \
-            python-dev \
-            libmysqlclient-dev \
-	    unattended-upgrades && \
-            rm -r /var/lib/apt/lists/*
+	apt-get install -y --no-install-recommends \
+		git \
+		python3-pip \
+		python3-dev \
+		libmysqlclient-dev \
+		unattended-upgrades && \
+	rm -r /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip \ 
 	&& pip install "django==1.10" \ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ RUN apt-get update && \
 		unattended-upgrades && \
 	rm -r /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip \ 
-	&& pip install "django==1.10" \ 
-	&& pip install "mysqlclient==1.3.8" \
-	&& pip install "kafka-python<=1.0" \
-	&& pip install "elasticsearch<3.0"
+RUN pip install --upgrade pip && pip install \
+	"django==2.1" \
+	"mysqlclient==1.3.13" \
+	"kafka-python<=1.0" \
+	"elasticsearch<3.0"
 
 ENV LANG=en_US.UTF-8 PYTHONHASHSEED=random \
     PATH=/usr/local/python/bin:/usr/local/apache/bin:$PATH \


### PR DESCRIPTION
Breaking changes:
https://docs.djangoproject.com/en/2.1/releases/2.0/#backwards-incompatible-changes-in-2-0
https://docs.djangoproject.com/en/2.1/releases/2.1/#backwards-incompatible-changes-in-2-1

Tested working with minimal changes:
- Specify `on_delete` argument for ForeignKey and OneToOneField
- `django.core.urlresolvers` is now `django.urls` (referenced in [project 3](https://github.com/thomaspinckney3/cs4501/blob/master/Project3.md#unit-testing))

I'll make a pull request for documentation changes on the cs4501 repo later